### PR TITLE
Move project to use latest WebView2 SDK 0.8.270

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -186,7 +186,7 @@ BOOL BrowserWindow::InitInstance(HINSTANCE hInstance, int nCmdShow)
     // tabs will be created from this environment and kept isolated from the
     // browser UI. This enviroment is created first so the UI can request new
     // tabs when it's ready.
-    HRESULT hr = CreateWebView2EnvironmentWithDetails(nullptr, userDataDirectory.c_str(), WEBVIEW2_RELEASE_CHANNEL_PREFERENCE_STABLE,
+    HRESULT hr = CreateWebView2EnvironmentWithDetails(nullptr, userDataDirectory.c_str(),
         L"", Callback<IWebView2CreateWebView2EnvironmentCompletedHandler>(
             [this](HRESULT result, IWebView2Environment* env) -> HRESULT
     {
@@ -220,7 +220,7 @@ HRESULT BrowserWindow::InitUIWebViews()
 
     // Create WebView environment for browser UI. A separate data directory is
     // used to isolate the browser UI from web content requested by the user.
-    return CreateWebView2EnvironmentWithDetails(nullptr, browserDataDirectory.c_str(), WEBVIEW2_RELEASE_CHANNEL_PREFERENCE_STABLE,
+    return CreateWebView2EnvironmentWithDetails(nullptr, browserDataDirectory.c_str(),
         L"", Callback<IWebView2CreateWebView2EnvironmentCompletedHandler>(
             [this](HRESULT result, IWebView2Environment* env) -> HRESULT
     {

--- a/WebViewBrowserApp.vcxproj
+++ b/WebViewBrowserApp.vcxproj
@@ -206,7 +206,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.190610.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.190610.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets" Condition="Exists('packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets')" />
-    <Import Project="packages\Microsoft.Web.WebView2.0.8.230\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.0.8.230\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="packages\Microsoft.Web.WebView2.0.8.270\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.0.8.270\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -214,6 +214,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.190610.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.ImplementationLibrary.1.0.190610.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.0.8.230\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.0.8.230\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.0.8.270\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.0.8.270\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cpprestsdk.v141" version="2.10.12.1" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="0.8.230" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="0.8.270" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.190610.2" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This updates the project files to use the latest version of the WebView2 SDK version 0.8.270.
As part of this change the CreateWebView* loader exports changed to remove the CHANNEL_PREFERENCE parameter. There's a corresponding change to BrowserWindow.cpp to remove that parameter.