### PR TITLE
Move project to use latest WebView2 SDK 0.9.538

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,41 @@
 # WebView2Browser
-A web browser built with the [Microsoft Edge WebView2](https://docs.microsoft.com/microsoft-edge/hosting/webview2) control.
+
+A web browser built with the [Microsoft Edge WebView2](https://aka.ms/webview2) control.
 
 ![WebView2Browser](/screenshots/WebView2Browser.png)
 
 WebView2Browser is a sample Windows desktop application demonstrating the WebView2 control capabilities. It is built as a Win32 [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) project and makes use of both C++ and JavaScript in the WebView2 environment to power its features.
 
-WebView2Browser shows some of the simplest uses of WebView2 -such as creating and navigating a WebView, but also some more complex workflows like using the [PostWebMessageAsJson API](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2#postwebmessageasjson) to communicate WebViews in separate environments. It is intended as a rich code sample to look at how you can use WebView2 APIs to build your own app.
+WebView2Browser shows some of the simplest uses of WebView2 -such as creating and navigating a WebView, but also some more complex workflows like using the [PostWebMessageAsJson API](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#postwebmessageasjson) to communicate WebViews in separate environments. It is intended as a rich code sample to look at how you can use WebView2 APIs to build your own app.
 
 ## Requisites
-- [Microsoft Edge (Chromium)](https://www.microsoftedgeinsider.com/download/) installed on a supported OS.
-- [Visual Studio](https://visualstudio.microsoft.com/vs/) with C++ support installed.
+
+* [Microsoft Edge (Chromium)](https://www.microsoftedgeinsider.com/download/) installed on a supported OS.
+* [Visual Studio](https://visualstudio.microsoft.com/vs/) with C++ support installed.
 
 The Edge Canary channel is recommended for the installation and the minimum version is 82.0.430.0.
 
 ## Build the browser
+
 Clone the repository and open the solution in Visual Studio. WebView2 is already included as a NuGet package* in the project!
 
-- Clone this repository
-- Open the solution in Visual Studio 2019**
-- Make the changes listed below if you're using a Windows version below Windows 10.
-- Set the target you want to build (Debug/Release, x86/x64)
-- Build the solution
+* Clone this repository
+* Open the solution in Visual Studio 2019**
+* Make the changes listed below if you're using a Windows version below Windows 10.
+* Set the target you want to build (Debug/Release, x86/x64)
+* Build the solution
 
 That's it. Everything should be ready to just launch the app.
 
-*You can get the WebView2 NugetPackage through the Visual Studio NuGet Package Manager.
-<br />
+*You can get the WebView2 NugetPackage through the Visual Studio NuGet Package Manager.  
 **You can also use Visual Studio 2017 by changing the project's Platform Toolset in Project Properties/Configuration properties/General/Platform Toolset. You might also need to change the Windows SDK to the latest version available to you.
 
 ## Using versions below Windows 10
+
 There's a couple of changes you need to make if you want to build and run the browser in other versions of Windows. This is because of how DPI is handled in Windows 10 vs previous versions of Windows.
 
 In `WebViewBrowserApp.cpp`, you will need to replace the call to `SetProcessDpiAwarenessContext` and call `SetProcessDPIAware` instead.
+
 ```cpp
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                       _In_opt_ HINSTANCE hPrevInstance,
@@ -51,6 +55,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 ```
 
 In `BrowserWindow.cpp`, you will need to remove the call to `GetDpiForWindow`.
+
 ```cpp
 int BrowserWindow::GetDPIAwareBound(int bound)
 {
@@ -62,6 +67,7 @@ int BrowserWindow::GetDPIAwareBound(int bound)
 ```
 
 ## Browser layout
+
 WebView2Browser has a multi-WebView approach to integrate web content and application UI into a Windows Desktop application. This allows the browser to use standard web technologies (HTML, CSS, JavaScript) to light up the interface but also enables the app to fetch favicons from the web and use IndexedDB for storing favorites and history.
 
 The multi-WebView approach involves using two separate WebView environments (each with its own user data directory): one for the UI WebViews and the other for all content WebViews. UI WebViews (controls and options dropdown) use the UI environment while web content WebViews (one per tab) use the content environment.
@@ -69,20 +75,22 @@ The multi-WebView approach involves using two separate WebView environments (eac
 ![Browser layout](https://github.com/MicrosoftEdge/WebView2Browser/raw/master/screenshots/layout.png)
 
 ## Features
+
 WebView2Browser provides all the functionalities to make a basic web browser, but there's plenty of room for you to play around.
 
-- Go back/forward
-- Reload page
-- Cancel navigation
-- Multiple tabs
-- History
-- Favorites
-- Search from the address bar
-- Page security status
-- Clearing cache and cookies
+* Go back/forward
+* Reload page
+* Cancel navigation
+* Multiple tabs
+* History
+* Favorites
+* Search from the address bar
+* Page security status
+* Clearing cache and cookies
 
 ## WebView2 APIs
-WebView2Browser makes use of a handful of the APIs available in WebView2. For the APIs not used here, you can find more about them in the [Microsoft Edge WebView2 Reference](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference-webview2). The following is a list of the most interesting APIs WebView2Browser uses and the feature(s) they enable.
+
+WebView2Browser makes use of a handful of the APIs available in WebView2. For the APIs not used here, you can find more about them in the [Microsoft Edge WebView2 Reference](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488-reference-webview2). The following is a list of the most interesting APIs WebView2Browser uses and the feature(s) they enable.
 
 API | Feature(s)
 :--- | :---
@@ -92,11 +100,11 @@ ICoreWebView2DevToolsProtocolEventReceivedEventHandler | Used along with add_Dev
 ICoreWebView2DevToolsProtocolEventReceiver | Used along with add_DevToolsProtocolEventReceived to listen for CDP security events to update the lock icon in the browser UI. |
 ICoreWebView2ExecuteScriptCompletedHandler | Used along with ExecuteScript to get the title and favicon from the visited page. |
 ICoreWebView2FocusChangedEventHandler | Used along with add_LostFocus to hide the browser options dropdown when it loses focus.
-ICoreWebView2HistoryChangedEventHandler | Used along with add_HistoryChanged to udpate the navigation buttons in the browser UI. |
+ICoreWebView2HistoryChangedEventHandler | Used along with add_HistoryChanged to update the navigation buttons in the browser UI. |
 ICoreWebView2Controller | There are several WebViewControllers in WebView2Browser and we fetch the associated WebViews from them.
-ICoreWebView2NavigationCompletedEventHandler | Used along with add_NavigationCompleted to udpate the reload button in the browser UI.
+ICoreWebView2NavigationCompletedEventHandler | Used along with add_NavigationCompleted to update the reload button in the browser UI.
 ICoreWebView2Settings | Used to disable DevTools in the browser UI.
-ICoreWebView2SourceChangedEventHandler | Used along with add_SourceChanged to udpate the address bar in the browser UI. |
+ICoreWebView2SourceChangedEventHandler | Used along with add_SourceChanged to update the address bar in the browser UI. |
 ICoreWebView2WebMessageReceivedEventHandler | This is one of the most important APIs to WebView2Browser. Most functionalities involving communication across WebViews use this.
 
 ICoreWebView2 API | Feature(s)
@@ -114,26 +122,28 @@ ICoreWebView2Controller API | Feature(s)
 :--- | :---
 get_CoreWebView2 | Used to get the CoreWebView2 associated with this CoreWebView2Controller.
 add_LostFocus | Used to hide the options dropdown when the user clicks away of it.
-<br />
 
 ## Implementing the features
+
 The sections below describe how some of the features in WebView2Browser were implemented. You can look at the source code for more details about how everything works here.
 
-- [The basics](#the-basics)
-    - [Set up the environment, create a WebView](#set-up-the-environment-create-a-webview)
-    - [Navigate to web page](#navigate-to-web-page)
-    - [Updating the address bar](#updating-the-address-bar)
-    - [Going back, going forward](#going-back-going-forward)
-- [Some interesting features](#some-interesting-features)
-    - [Communicating the WebViews](#communicating-the-webviews)
-    - [Tab handling](#tab-handling)
-    - [Updating the security icon](#updating-the-security-icon)
-    - [Populating the history](#populating-the-history)
-- [Handling JSON and URIs](#handling-json-and-uris)
+* [The basics](#the-basics)
+  * [Set up the environment, create a WebView](#set-up-the-environment-create-a-webview)
+  * [Navigate to web page](#navigate-to-web-page)
+  * [Updating the address bar](#updating-the-address-bar)
+  * [Going back, going forward](#going-back-going-forward)
+* [Some interesting features](#some-interesting-features)
+  * [Communicating the WebViews](#communicating-the-webviews)
+  * [Tab handling](#tab-handling)
+  * [Updating the security icon](#updating-the-security-icon)
+  * [Populating the history](#populating-the-history)
+* [Handling JSON and URIs](#handling-json-and-uris)
 
 ## The basics
+
 ### Set up the environment, create a WebView
-WebView2 allows you to host web content in your Windows app. It exposes the globals [CreateCoreWebView2Environment](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/webview2.idl#createcorewebview2environment) and [CreateCoreWebView2EnvironmentWithOptions](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/webview2.idl#createcorewebview2environmentwithoptions) from which we can create the two separate environments for the browser's UI and content.
+
+WebView2 allows you to host web content in your Windows app. It exposes the globals [CreateCoreWebView2Environment](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/webview2-idl#createcorewebview2environment) and [CreateCoreWebView2EnvironmentWithOptions](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/webview2-idl#createcorewebview2environmentwithoptions) from which we can create the two separate environments for the browser's UI and content.
 
 ```cpp
     // Get directory for user data. This will be kept separated from the
@@ -143,7 +153,7 @@ WebView2 allows you to host web content in your Windows app. It exposes the glob
 
     // Create WebView environment for web content requested by the user. All
     // tabs will be created from this environment and kept isolated from the
-    // browser UI. This enviroment is created first so the UI can request new
+    // browser UI. This environment is created first so the UI can request new
     // tabs when it's ready.
     HRESULT hr = CreateCoreWebView2EnvironmentWithOptions(nullptr, userDataDirectory.c_str(),
         L"", Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
@@ -162,6 +172,7 @@ WebView2 allows you to host web content in your Windows app. It exposes the glob
         return hr;
     }).Get());
 ```
+
 ```cpp
 HRESULT BrowserWindow::InitUIWebViews()
 {
@@ -186,7 +197,7 @@ HRESULT BrowserWindow::InitUIWebViews()
 }
 ```
 
-We use the [ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2createcorewebview2environmentcompletedhandler) to create the UI WebViews once the environment is ready.
+We use the [ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2createcorewebview2environmentcompletedhandler) to create the UI WebViews once the environment is ready.
 
 ```cpp
 HRESULT BrowserWindow::CreateBrowserControlsWebView()
@@ -225,9 +236,11 @@ HRESULT BrowserWindow::CreateBrowserControlsWebView()
     }).Get());
 }
 ```
-We're setting up a few things here. The [ICoreWebView2Settings](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2settings) interface is used to disable DevTools in the WebView powering the browser controls. We're also adding a handler for received web messages. This handler will enable us to do something when the user interacts with the controls in this WebView.
+
+We're setting up a few things here. The [ICoreWebView2Settings](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2settings) interface is used to disable DevTools in the WebView powering the browser controls. We're also adding a handler for received web messages. This handler will enable us to do something when the user interacts with the controls in this WebView.
 
 ### Navigate to web page
+
 You can navigate to a web page by entering its URI in the address bar. When pressing Enter, the controls WebView will post a web message to the host app so it can navigate the active tab to the specified location. Code below shows how the host Win32 application will handle that message.
 
 ```cpp
@@ -262,9 +275,11 @@ You can navigate to a web page by entering its URI in the address bar. When pres
         }
         break;
 ```
+
 WebView2Browser will check the URI against browser pages (i.e. favorites, settings, history) and navigate to the requested location or use the provided URI to search Bing as a fallback.
 
 ### Updating the address bar
+
 The address bar is updated every time there is a change in the active tab's document source and along with other controls when switching tabs. Each WebView will fire an event when the state of the document changes, we can use this event to get the new source on updates and forward the change to the controls WebView (we'll also update the go back and go forward buttons).
 
 ```cpp
@@ -277,6 +292,7 @@ The address bar is updated every time there is a change in the active tab's docu
             return S_OK;
         }).Get(), &m_uriUpdateForwarderToken));
 ```
+
 ```cpp
 HRESULT BrowserWindow::HandleTabURIUpdate(size_t tabId, ICoreWebView2* webview)
 {
@@ -313,7 +329,9 @@ HRESULT BrowserWindow::HandleTabHistoryUpdate(size_t tabId, ICoreWebView2* webvi
     return S_OK;
 }
 ```
-We have sent the `MG_UPDATE_URI` message along with the URI to the controls WebView. Now we want to reflect those changes on the tab state and udpate the UI if necessary.
+
+We have sent the `MG_UPDATE_URI` message along with the URI to the controls WebView. Now we want to reflect those changes on the tab state and update the UI if necessary.
+
 ```javascript
         case commands.MG_UPDATE_URI:
             if (isValidTabId(args.tabId)) {
@@ -337,9 +355,11 @@ We have sent the `MG_UPDATE_URI` message along with the URI to the controls WebV
 ```
 
 ### Going back, going forward
+
 Each WebView will keep a history for the navigations it has performed so we only need to connect the browser UI with the corresponding methods. If the active tab's WebView can be navigated back/forward, the buttons will post a web message to the host application when clicked.
 
 The JavaScript side:
+
 ```javascript
     document.querySelector('#btn-forward').addEventListener('click', function(e) {
         if (document.getElementById('btn-forward').className === 'btn') {
@@ -361,7 +381,9 @@ The JavaScript side:
         }
     });
 ```
+
 The host application side:
+
 ```cpp
         case MG_GO_FORWARD:
         {
@@ -376,7 +398,9 @@ The host application side:
 ```
 
 ### Reloading, stop navigation
-We use the `NavigationStarting` event fired by a content WebView to udpate its associated tab loading state in the controls WebView. Similarly, when a WebView fires the `NavigationCompleted` event, we use that event to instruct the controls WebView to update the tab state. The active tab state in the controls WebView will determine whether to show the reload or the cancel button. Each of those will post a message back to the host application when clicked, so that the WebView for that tab can be reloaded or have its navigation canceled, accordingly.
+
+We use the `NavigationStarting` event fired by a content WebView to update its associated tab loading state in the controls WebView. Similarly, when a WebView fires the `NavigationCompleted` event, we use that event to instruct the controls WebView to update the tab state. The active tab state in the controls WebView will determine whether to show the reload or the cancel button. Each of those will post a message back to the host application when clicked, so that the WebView for that tab can be reloaded or have its navigation canceled, accordingly.
+
 ```javascript
 function reloadActiveTabContent() {
     var message = {
@@ -401,6 +425,7 @@ function reloadActiveTabContent() {
         }
     });
 ```
+
 ```cpp
         case MG_RELOAD:
         {
@@ -414,8 +439,11 @@ function reloadActiveTabContent() {
 ```
 
 ## Some interesting features
+
 ### Communicating the WebViews
-We need to communicate the WebViews powering tabs and UI so that user interactions in one have the desired effect in the other. WebView2Browser makes use of set of very useful WebView2 APIs for this purpose, including [PostWebMessageAsJson](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2#postwebmessageasjson), [add_WebMessageReceived](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2#add_webmessagereceived) and [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2webmessagereceivedeventhandler). On the JavaScript side, we're making use of the `window.chrome.webview` object exposed to call the `postMessage` method and add an event lister for received messages.
+
+We need to communicate the WebViews powering tabs and UI so that user interactions in one have the desired effect in the other. WebView2Browser makes use of set of very useful WebView2 APIs for this purpose, including [PostWebMessageAsJson](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#postwebmessageasjson), [add_WebMessageReceived](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#add_webmessagereceived) and [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2webmessagereceivedeventhandler). On the JavaScript side, we're making use of the `window.chrome.webview` object exposed to call the `postMessage` method and add an event lister for received messages.
+
 ```cpp
 HRESULT BrowserWindow::CreateBrowserControlsWebView()
 {
@@ -432,6 +460,7 @@ HRESULT BrowserWindow::CreateBrowserControlsWebView()
     }).Get());
 }
 ```
+
 ```cpp
 HRESULT BrowserWindow::PostJsonToWebView(web::json::value jsonObj, ICoreWebView2* webview)
 {
@@ -453,6 +482,7 @@ HRESULT BrowserWindow::HandleTabNavStarting(size_t tabId, ICoreWebView2* webview
     return PostJsonToWebView(jsonObj, m_controlsWebView.Get());
 }
 ```
+
 ```javascript
 function init() {
     window.chrome.webview.addEventListener('message', messageHandler);
@@ -472,8 +502,11 @@ function reloadActiveTabContent() {
     window.chrome.webview.postMessage(message);
 }
 ```
+
 ### Tab handling
+
 A new tab will be created whenever the user clicks on the new tab button to the right of the open tabs. The controls WebView will post a message to the host application to create the WebView for that tab and create an object tracking its state.
+
 ```javascript
 function createNewTab(shouldBeActive) {
     const tabId = getNewTabId();
@@ -508,7 +541,9 @@ function createNewTab(shouldBeActive) {
     }
 }
 ```
-On the host app side, the registered [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2webmessagereceivedeventhandler) will catch the message and create the WebView for that tab.
+
+On the host app side, the registered [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2webmessagereceivedeventhandler) will catch the message and create the WebView for that tab.
+
 ```cpp
         case MG_CREATE_TAB:
         {
@@ -529,6 +564,7 @@ On the host app side, the registered [ICoreWebView2WebMessageReceivedEventHandle
         }
         break;
 ```
+
 ```cpp
 std::unique_ptr<Tab> Tab::CreateNewTab(HWND hWnd, ICoreWebView2Environment* env, size_t id, bool shouldBeActive)
 {
@@ -585,7 +621,7 @@ HRESULT Tab::Init(ICoreWebView2Environment* env, bool shouldBeActive)
         RETURN_IF_FAILED(m_contentWebView->add_NavigationCompleted(Callback<ICoreWebView2NavigationCompletedEventHandler>(
             [this, browserWindow](ICoreWebView2* webview, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT
         {
-            BrowserWindow::CheckFailure(browserWindow->HandleTabNavCompleted(m_tabId, webview, args), L"Can't udpate reload button");
+            BrowserWindow::CheckFailure(browserWindow->HandleTabNavCompleted(m_tabId, webview, args), L"Can't update reload button");
             return S_OK;
         }).Get(), &m_navCompletedToken));
 
@@ -598,7 +634,9 @@ HRESULT Tab::Init(ICoreWebView2Environment* env, bool shouldBeActive)
     }).Get());
 }
 ```
+
 The tab registers all handlers so it can forward updates to the controls WebView when events fire. The tab is ready and will be shown on the content area of the browser. Clicking on a tab in the controls WebView will post a message to the host application, which will in turn hide the WebView for the previously active tab and show the one for the clicked tab.
+
 ```cpp
 HRESULT BrowserWindow::SwitchToTab(size_t tabId)
 {
@@ -618,7 +656,9 @@ HRESULT BrowserWindow::SwitchToTab(size_t tabId)
 ```
 
 ### Updating the security icon
-We use the [CallDevToolsProtocolMethod](https://docs.microsoft.com/microsoft-edge/hosting/webview2/reference/icorewebview2#calldevtoolsprotocolmethod) to enable listening for security events. Whenever a `securityStateChanged` event is fired, we will use the new state to update the security icon on the controls WebView.
+
+We use the [CallDevToolsProtocolMethod](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#calldevtoolsprotocolmethod) to enable listening for security events. Whenever a `securityStateChanged` event is fired, we will use the new state to update the security icon on the controls WebView.
+
 ```cpp
         // Enable listening for security events to update secure icon
         RETURN_IF_FAILED(m_contentWebView->CallDevToolsProtocolMethod(L"Security.enable", L"{}", nullptr));
@@ -629,10 +669,11 @@ We use the [CallDevToolsProtocolMethod](https://docs.microsoft.com/microsoft-edg
         RETURN_IF_FAILED(m_securityStateChangedReceiver->add_DevToolsProtocolEventReceived(Callback<ICoreWebView2DevToolsProtocolEventReceivedEventHandler>(
             [this, browserWindow](ICoreWebView2* webview, ICoreWebView2DevToolsProtocolEventReceivedEventArgs* args) -> HRESULT
         {
-            BrowserWindow::CheckFailure(browserWindow->HandleTabSecurityUpdate(m_tabId, webview, args), L"Can't udpate security icon");
+            BrowserWindow::CheckFailure(browserWindow->HandleTabSecurityUpdate(m_tabId, webview, args), L"Can't update security icon");
             return S_OK;
         }).Get(), &m_securityUpdateToken));
 ```
+
 ```cpp
 HRESULT BrowserWindow::HandleTabSecurityUpdate(size_t tabId, ICoreWebView2* webview, ICoreWebView2DevToolsProtocolEventReceivedEventArgs* args)
 {
@@ -649,6 +690,7 @@ HRESULT BrowserWindow::HandleTabSecurityUpdate(size_t tabId, ICoreWebView2* webv
     return PostJsonToWebView(jsonObj, m_controlsWebView.Get());
 }
 ```
+
 ```javascript
         case commands.MG_SECURITY_UPDATE:
             if (isValidTabId(args.tabId)) {
@@ -663,9 +705,11 @@ HRESULT BrowserWindow::HandleTabSecurityUpdate(size_t tabId, ICoreWebView2* webv
 ```
 
 ### Populating the history
+
 WebView2Browser uses IndexedDB in the controls WebView to store history items, just an example of how WebView2 enables you to access standard web technologies as you would in the browser. The item for a navigation will be created as soon as the URI is updated. These items are then retrieved by the history UI in a tab making use of `window.chrome.postMessage`.
 
 In this case, most functionality is implemented using JavaScript on both ends (controls WebView and content WebView loading the UI) so the host application is only acting as a message broker to communicate those ends.
+
 ```javascript
         case commands.MG_UPDATE_URI:
             if (isValidTabId(args.tabId)) {
@@ -693,6 +737,7 @@ In this case, most functionality is implemented using JavaScript on both ends (c
             }
             break;
 ```
+
 ```javascript
 function addHistoryItem(item, callback) {
     queryDB((db) => {
@@ -739,8 +784,11 @@ function addHistoryItem(item, callback) {
     });
 }
 ```
+
 ## Handling JSON and URIs
-WebView2Browser uses Microsoft's [cpprestsdk (Casablanca)](https://github.com/Microsoft/cpprestsdk) to handle all JSON in the C++ side of thigs. IUri and CreateUri are also used to parse file paths into URIs and can be used to for other URIs as well.
+
+WebView2Browser uses Microsoft's [cpprestsdk (Casablanca)](https://github.com/Microsoft/cpprestsdk) to handle all JSON in the C++ side of things. IUri and CreateUri are also used to parse file paths into URIs and can be used to for other URIs as well.
 
 ## Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 A web browser built with the [Microsoft Edge WebView2](https://aka.ms/webview2) control.
 
-![WebView2Browser](/screenshots/WebView2Browser.png)
+![WebView2Browser](screenshots/WebView2Browser.png)
 
 WebView2Browser is a sample Windows desktop application demonstrating the WebView2 control capabilities. It is built as a Win32 [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) project and makes use of both C++ and JavaScript in the WebView2 environment to power its features.
 
-WebView2Browser shows some of the simplest uses of WebView2 -such as creating and navigating a WebView, but also some more complex workflows like using the [PostWebMessageAsJson API](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#postwebmessageasjson) to communicate WebViews in separate environments. It is intended as a rich code sample to look at how you can use WebView2 APIs to build your own app.
+WebView2Browser shows some of the simplest uses of WebView2 -such as creating and navigating a WebView, but also some more complex workflows like using the [PostWebMessageAsJson API](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2#postwebmessageasjson) to communicate WebViews in separate environments. It is intended as a rich code sample to look at how you can use WebView2 APIs to build your own app.
 
 ## Requisites
 
 * [Microsoft Edge (Chromium)](https://www.microsoftedgeinsider.com/download/) installed on a supported OS.
 * [Visual Studio](https://visualstudio.microsoft.com/vs/) with C++ support installed.
 
-The Edge Canary channel is recommended for the installation and the minimum version is 82.0.430.0.
+The Edge Canary channel is recommended for the installation and the minimum version is 85.0.538.0.
 
 ## Build the browser
 
@@ -72,7 +72,7 @@ WebView2Browser has a multi-WebView approach to integrate web content and applic
 
 The multi-WebView approach involves using two separate WebView environments (each with its own user data directory): one for the UI WebViews and the other for all content WebViews. UI WebViews (controls and options dropdown) use the UI environment while web content WebViews (one per tab) use the content environment.
 
-![Browser layout](https://github.com/MicrosoftEdge/WebView2Browser/raw/master/screenshots/layout.png)
+![Browser layout](screenshots/layout.png)
 
 ## Features
 
@@ -90,7 +90,7 @@ WebView2Browser provides all the functionalities to make a basic web browser, bu
 
 ## WebView2 APIs
 
-WebView2Browser makes use of a handful of the APIs available in WebView2. For the APIs not used here, you can find more about them in the [Microsoft Edge WebView2 Reference](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488-reference-webview2). The following is a list of the most interesting APIs WebView2Browser uses and the feature(s) they enable.
+WebView2Browser makes use of a handful of the APIs available in WebView2. For the APIs not used here, you can find more about them in the [Microsoft Edge WebView2 Reference](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538-reference-webview2). The following is a list of the most interesting APIs WebView2Browser uses and the feature(s) they enable.
 
 API | Feature(s)
 :--- | :---
@@ -143,7 +143,7 @@ The sections below describe how some of the features in WebView2Browser were imp
 
 ### Set up the environment, create a WebView
 
-WebView2 allows you to host web content in your Windows app. It exposes the globals [CreateCoreWebView2Environment](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/webview2-idl#createcorewebview2environment) and [CreateCoreWebView2EnvironmentWithOptions](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/webview2-idl#createcorewebview2environmentwithoptions) from which we can create the two separate environments for the browser's UI and content.
+WebView2 allows you to host web content in your Windows app. It exposes the globals [CreateCoreWebView2Environment](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/webview2-idl#createcorewebview2environment) and [CreateCoreWebView2EnvironmentWithOptions](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/webview2-idl#createcorewebview2environmentwithoptions) from which we can create the two separate environments for the browser's UI and content.
 
 ```cpp
     // Get directory for user data. This will be kept separated from the
@@ -197,7 +197,7 @@ HRESULT BrowserWindow::InitUIWebViews()
 }
 ```
 
-We use the [ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2createcorewebview2environmentcompletedhandler) to create the UI WebViews once the environment is ready.
+We use the [ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2createcorewebview2environmentcompletedhandler) to create the UI WebViews once the environment is ready.
 
 ```cpp
 HRESULT BrowserWindow::CreateBrowserControlsWebView()
@@ -237,7 +237,7 @@ HRESULT BrowserWindow::CreateBrowserControlsWebView()
 }
 ```
 
-We're setting up a few things here. The [ICoreWebView2Settings](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2settings) interface is used to disable DevTools in the WebView powering the browser controls. We're also adding a handler for received web messages. This handler will enable us to do something when the user interacts with the controls in this WebView.
+We're setting up a few things here. The [ICoreWebView2Settings](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2settings) interface is used to disable DevTools in the WebView powering the browser controls. We're also adding a handler for received web messages. This handler will enable us to do something when the user interacts with the controls in this WebView.
 
 ### Navigate to web page
 
@@ -442,7 +442,7 @@ function reloadActiveTabContent() {
 
 ### Communicating the WebViews
 
-We need to communicate the WebViews powering tabs and UI so that user interactions in one have the desired effect in the other. WebView2Browser makes use of set of very useful WebView2 APIs for this purpose, including [PostWebMessageAsJson](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#postwebmessageasjson), [add_WebMessageReceived](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#add_webmessagereceived) and [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2webmessagereceivedeventhandler). On the JavaScript side, we're making use of the `window.chrome.webview` object exposed to call the `postMessage` method and add an event lister for received messages.
+We need to communicate the WebViews powering tabs and UI so that user interactions in one have the desired effect in the other. WebView2Browser makes use of set of very useful WebView2 APIs for this purpose, including [PostWebMessageAsJson](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2#postwebmessageasjson), [add_WebMessageReceived](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2#add_webmessagereceived) and [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2webmessagereceivedeventhandler). On the JavaScript side, we're making use of the `window.chrome.webview` object exposed to call the `postMessage` method and add an event lister for received messages.
 
 ```cpp
 HRESULT BrowserWindow::CreateBrowserControlsWebView()
@@ -542,7 +542,7 @@ function createNewTab(shouldBeActive) {
 }
 ```
 
-On the host app side, the registered [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2webmessagereceivedeventhandler) will catch the message and create the WebView for that tab.
+On the host app side, the registered [ICoreWebView2WebMessageReceivedEventHandler](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2webmessagereceivedeventhandler) will catch the message and create the WebView for that tab.
 
 ```cpp
         case MG_CREATE_TAB:
@@ -657,7 +657,7 @@ HRESULT BrowserWindow::SwitchToTab(size_t tabId)
 
 ### Updating the security icon
 
-We use the [CallDevToolsProtocolMethod](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-488/icorewebview2#calldevtoolsprotocolmethod) to enable listening for security events. Whenever a `securityStateChanged` event is fired, we will use the new state to update the security icon on the controls WebView.
+We use the [CallDevToolsProtocolMethod](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/0-9-538/icorewebview2#calldevtoolsprotocolmethod) to enable listening for security events. Whenever a `securityStateChanged` event is fired, we will use the new state to update the security icon on the controls WebView.
 
 ```cpp
         // Enable listening for security events to update secure icon

--- a/WebViewBrowserApp.vcxproj
+++ b/WebViewBrowserApp.vcxproj
@@ -205,15 +205,15 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets" Condition="Exists('packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets')" />
-    <Import Project="packages\Microsoft.Web.WebView2.0.9.488\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.0.9.488\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.191107.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.191107.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="packages\Microsoft.Web.WebView2.0.9.538\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('packages\Microsoft.Web.WebView2.0.9.538\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cpprestsdk.v141.2.10.12.1\build\native\cpprestsdk.v141.targets'))" />
-    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.0.9.488\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.0.9.488\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.191107.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.ImplementationLibrary.1.0.191107.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Web.WebView2.0.9.538\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Web.WebView2.0.9.538\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/WebViewBrowserApp.vcxproj.filters
+++ b/WebViewBrowserApp.vcxproj.filters
@@ -61,6 +61,5 @@
   <ItemGroup>
     <None Include="ui_bar.html" />
     <None Include="packages.config" />
-    <None Include="$(MSBuildThisFileDirectory)$(EffectivePlatform)\WebView2Loader.dll" />
   </ItemGroup>
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cpprestsdk.v141" version="2.10.12.1" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="0.9.488" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="0.9.538" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.191107.2" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This updates the project files to use the latest version of the WebView2 SDK version 0.9.538.

As part of this change:
 - Updated links in `README.md`

For more information about SDK 0.9.538, check out WebView2 [release notes](https://docs.microsoft.com/microsoft-edge/webview2/releasenotes#09538).